### PR TITLE
Fix two-way transcript download header handling

### DIFF
--- a/src/main/modules/ipchandlers.js
+++ b/src/main/modules/ipchandlers.js
@@ -578,7 +578,7 @@ export function registerIpcHandlers() {
             ipcHandlerLog.info("Download request finished.");
             if (response.statusCode >= 200 && response.statusCode < 300) {
               const buffer = Buffer.concat(chunks);
-              resolve({ status: "ok", data: buffer });
+              resolve({ status: "ok", data: buffer, headers: response.headers });
             } else {
               const responseBody = Buffer.concat(chunks).toString();
               let errorMessage = `Download failed with status: ${response.statusCode}`;

--- a/src/renderer/src/components/session/vtt-download.jsx
+++ b/src/renderer/src/components/session/vtt-download.jsx
@@ -12,7 +12,7 @@ function DownloadVttButton({ isDownloadable, integration, sessionId, token }) {
   const { t } = useTranslation();
 
   const handleDownload = async () => {
-    if (isLoading || !isDownloadable) return;
+    if (isLoading || !isDownloadable || !integration || !sessionId) return;
 
     setIsLoading(true);
 
@@ -33,7 +33,10 @@ function DownloadVttButton({ isDownloadable, integration, sessionId, token }) {
       const link = document.createElement("a");
       link.href = blobUrl;
 
-      const disposition = response.headers.get("content-disposition") || "";
+      const dispositionHeader = response?.headers?.["content-disposition"];
+      const disposition = Array.isArray(dispositionHeader)
+        ? dispositionHeader[0]
+        : dispositionHeader || "";
       const filenameMatch = disposition.match(
         /filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i,
       );


### PR DESCRIPTION
### Motivation
- Prevent a runtime `Cannot read properties of undefined` error when downloading two-way transcripts caused by treating IPC response headers like a Fetch `Response` object. 
- Avoid issuing malformed download requests by ensuring `integration` and `sessionId` are present before starting a download. 

### Description
- Added a guard in `src/renderer/src/components/session/vtt-download.jsx` to return early if `integration` or `sessionId` are missing. 
- Changed filename extraction in `src/renderer/src/components/session/vtt-download.jsx` to handle Electron IPC-style `response.headers` (plain object or arrays) instead of calling `headers.get(...)`. 
- Updated the main-process `download-vtt` handler in `src/main/modules/ipchandlers.js` to include `response.headers` in successful IPC responses so the renderer can parse `content-disposition` for server filenames. 

### Testing
- Ran `npm run build` (Electron/Vite production build) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdd4093ac8325a2c2843a875f3f93)